### PR TITLE
refactor: use TwoFactor purpose for auth-code email body

### DIFF
--- a/src/Blogsphere.Notification.Service/EventBus/Consumers/AuthCodeSentConsumer.cs
+++ b/src/Blogsphere.Notification.Service/EventBus/Consumers/AuthCodeSentConsumer.cs
@@ -34,6 +34,7 @@ public class AuthCodeSentConsumer(
             "SelfResetPassword" => AuthCodeEmailBody.SelfResetPassword,
             "Disable2FA" => AuthCodeEmailBody.Disable2FA,
             "SignIn" => AuthCodeEmailBody.SignIn,
+            "TwoFactor" => AuthCodeEmailBody.TwoFactor,
             _ => throw new InvalidOperationException($"Invalid purpose: {purpose}")
         };
         return JsonConvert.SerializeObject(new List<TemplateFields>

--- a/src/Blogsphere.Notification.Service/EventBus/Consumers/AuthCodeSentConsumer.cs
+++ b/src/Blogsphere.Notification.Service/EventBus/Consumers/AuthCodeSentConsumer.cs
@@ -33,7 +33,6 @@ public class AuthCodeSentConsumer(
         {
             "SelfResetPassword" => AuthCodeEmailBody.SelfResetPassword,
             "Disable2FA" => AuthCodeEmailBody.Disable2FA,
-            "SignIn" => AuthCodeEmailBody.SignIn,
             "TwoFactor" => AuthCodeEmailBody.TwoFactor,
             _ => throw new InvalidOperationException($"Invalid purpose: {purpose}")
         };

--- a/src/Blogsphere.Notification.Service/Models/Constants/AuthCodeEmailBody.cs
+++ b/src/Blogsphere.Notification.Service/Models/Constants/AuthCodeEmailBody.cs
@@ -4,5 +4,5 @@ public class AuthCodeEmailBody
 {
     public const string SelfResetPassword = "We received a request to reset your Blogsphere account password. To complete the process, please use the verification code below:";
     public const string Disable2FA = "We received a request to disable two-factor authentication (2FA) for your Blogsphere account. To complete the process, please use the verification code below:";
-    public const string SignIn = "We received a request to sign in to your Blogsphere account. To complete the sign-in process, please use the verification code below:";
+    public const string TwoFactor = "We received a request to sign in to your Blogsphere account. To complete the sign-in process, please use the verification code below:";
 }


### PR DESCRIPTION
## Summary
- Align the auth-code email template body constant with the **TwoFactor** purpose value sent in `AdditionalProperties`.
- Remove the separate **SignIn** branch in favor of **TwoFactor** so naming matches two-factor sign-in flows.
- Keep **SelfResetPassword** and **Disable2FA** behavior unchanged.

## Changes
- **Consumers:** `AuthCodeSentConsumer` maps `purpose` to `AuthCodeEmailBody.TwoFactor` for the two-factor sign-in case.
- **Constants:** `AuthCodeEmailBody.SignIn` renamed to `TwoFactor` (same user-facing copy).

## Notes
- **Contract:** Producers must send `purpose: "TwoFactor"` (not `"SignIn"`) for this path, or the consumer will throw `InvalidOperationException` for an invalid purpose.